### PR TITLE
Fix app count after custom app success

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -152,9 +152,9 @@ function handleCustomApp(appTemplate) {
         modal.remove();
         checkDependencies(app)
           .then(()=>Comms.uploadApp(app,{device:device, language:LANGUAGE}))
-          .then(()=>{
+          .then((appInfo)=>{
             Progress.hide({sticky:true});
-            resolve();
+            resolve(appInfo);
           }).catch(e => {
             Progress.hide({sticky:true});
             reject(e);


### PR DESCRIPTION
Pass through `appInfo` so that is can be added to apps list later on:


Withouth this change `appJSON` in https://github.com/myxor/EspruinoAppLoaderCore/blob/2a8e872ecb143a10e53273b4d3473164e104e1d3/js/index.js#L482 is undefined and wont be added. Therefore the count of "installed" apps is not being increased.

With this change it is :)
