### PR TITLE
Changelog: Scroll to installed version if app is installed

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -40,7 +40,7 @@ httpGet(Const.APPS_JSON_FILE).then(apps=>{
   } catch(e) {
     console.log(e);
     showToast("App List Corrupted","error");
-  }  
+  }
   // fix up the JSON
   if (appJSON.length && appJSON[appJSON.length-1]===null)
     appJSON.pop(); // remove trailing null added to make auto-generation of apps.json easier
@@ -74,10 +74,27 @@ httpGet("appdates.csv").then(csv=>{
 });
 
 // ===========================================  Top Navigation
-function showChangeLog(appid) {
+function showChangeLog(appid, installedVersion) {
   let app = appNameToApp(appid);
   function show(contents) {
-    showPrompt(app.name+" Change Log",contents,{ok:true}).catch(()=>{});
+    let shouldEscapeHtml = true;
+    if (contents && installedVersion) {
+      let lines = contents.split("\n");
+      for(let i = 0; i < lines.length; i++) {
+        let line = lines[i];
+        if (line.startsWith(installedVersion)) {
+          line = '<a id="' + installedVersion + '"></a>' + line;
+          lines[i] = line;
+        }
+      }
+      contents = lines.join("<br>");
+      shouldEscapeHtml = false;
+    }
+    showPrompt(app.name+" ChangeLog",contents,{ok:true}, shouldEscapeHtml).catch(()=>{});
+    if (installedVersion) {
+      var elem = document.getElementById(installedVersion);
+      if (elem) elem.scrollIntoView();
+    }
   }
   httpGet(`apps/${appid}/ChangeLog`).
     then(show).catch(()=>show("No Change Log available"));

--- a/js/utils.js
+++ b/js/utils.js
@@ -149,6 +149,8 @@ function getVersionInfo(appListing, appInstalled) {
   let versionText = "";
   let canUpdate = false;
   function clicky(v) {
+    if (appInstalled)
+      return `<a class="c-hand" onclick="showChangeLog('${appListing.id}', '${appInstalled.version}')">${v}</a>`;
     return `<a class="c-hand" onclick="showChangeLog('${appListing.id}')">${v}</a>`;
   }
 


### PR DESCRIPTION
If an app is already installed we can scroll to the installed version when opening the ChangeLog of that app.

This is done using a HTML anchor which is then scrolled to after the ChangeLog popup is shown.



If the app is not installed (or appLoader is disconnected) everything works as before.




