### PR TITLE
Extended filtering

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -348,8 +348,8 @@ if (window.location.hash) {
   hashValue = decodeURIComponent(window.location.hash.slice(1)).toLowerCase();
   searchType = "hash";
 }
+let searchParams = new URLSearchParams(window.location.search);
 if (window.location.search) {
-  var searchParams = new URLSearchParams(window.location.search);
   if (searchParams.has("id")) {
     searchValue = searchParams.get("id").toLowerCase();
     searchType = "id";
@@ -859,6 +859,11 @@ const searchInputChangedDebounced = debounce(refreshLibrary, 300);
 librarySearchInput.addEventListener('input', evt => {
   searchValue = evt.target.value.toLowerCase();
   searchType = "full";
+  if (searchParams) {
+    searchParams.set("q", searchValue);
+    // Update window URL
+    window.history.replaceState(null, null, "?q=" + searchValue);
+  }
   searchInputChangedDebounced();
 });
 


### PR DESCRIPTION
 Possible filter types:

-  `.../BangleApps/#blue` shows apps having "blue" in app.id or app.tag --> searchType:hash (as before these changes)
-  `.../BangleApps/#bluetooth` shows apps having "bluetooth" in app.id or app.tag (also selects bluetooth chip) --> searchType:chip (as before these changes)
-  `.../BangleApps/id=antonclk` shows app having app.id == antonclk --> searchType:id
-  `.../BangleApps/q=clock` shows apps having "clock" in app.id or app.description --> searchType:full


Typing in the search field on the web interface does full search now (and the URL is changed according to the input value).


Fixes https://github.com/espruino/BangleApps/issues/1215

Note: there is no change in the sorting as suggested in comment https://github.com/espruino/BangleApps/issues/1215#issuecomment-1039131902 done.


@gfwilliams  even though i tested this i would like you to have a second look on this before merging :) Thanks!