### PR TITLE
Filter out more messages than the ones to Gadgetbridge

### DIFF
--- a/js/comms.js
+++ b/js/comms.js
@@ -113,12 +113,12 @@ const Comms = {
               console.log("<COMMS> Response: ",JSON.stringify(result));
               if (result) {
                 result=result.trim();
-                if (result=="OK") {
+                if (result=="###COMMS###-OK") {
                   uploadCmd(); // all as expected - send next
                   return;
                 }
-                if (result.startsWith("{") && result.endsWith("}")) {
-                  console.log("<COMMS> JSON response received (Gadgetbridge?) - ignoring...");
+                if (!result.startsWith("###COMMS###")) {
+                  console.log("<COMMS> Received response without ###COMMS### - ignoring...");
                   /* Here we have to poke around inside the Puck.js library internals. Basically
                   it just gave us the first line in the input buffer, but there may have been more.
                   We take the next line (or undefined) and call ourselves again to handle that.
@@ -143,7 +143,7 @@ const Comms = {
             }
             // Actually write the command with a 'print OK' at the end, and use responseHandler
             // to deal with the response. If OK we call uploadCmd to upload the next block
-            Puck.write(`${cmd};${Comms.getProgressCmd(currentBytes / maxBytes)}Bluetooth.println("OK")\n`,responseHandler, true /* wait for a newline*/);
+            Puck.write(`${cmd};${Comms.getProgressCmd(currentBytes / maxBytes)}Bluetooth.println("###COMMS###-OK")\n`,responseHandler, true /* wait for a newline*/);
           }
           uploadCmd();
         }


### PR DESCRIPTION
Apps printing stuff in boot makes the app loader practically useless without a codeless reboot of the watch.
This ignores all messages that don't start with ###COMMS### to filter those lines out.