### PR TITLE
allows to also favourable custom apps

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -357,7 +357,7 @@ function getAppHTML(app, appInstalled, forInterface) {
   </div>
   <div class="tile-action">`;
   if (forInterface=="library") html += `
-    <button class="btn btn-link btn-action btn-lg ${!app.custom?"":"d-hide"} btn-favourite" appid="${app.id}" title="Favorite"><i class="icon icon-favourite${favourite?" icon-favourite-active":""}"></i></button>
+    <button class="btn btn-link btn-action btn-lg btn-favourite" appid="${app.id}" title="Favorite"><i class="icon icon-favourite${favourite?" icon-favourite-active":""}"></i></button>
     <button class="btn btn-link btn-action btn-lg ${(appInstalled&&app.interface)?"":"d-hide"}" appid="${app.id}" title="Download data from app"><i class="icon icon-interface"></i></button>
     <button class="btn btn-link btn-action btn-lg ${app.allow_emulator?"":"d-hide"}" appid="${app.id}" title="Try in Emulator"><i class="icon icon-emulator"></i></button>
     <button class="btn btn-link btn-action btn-lg ${version.canUpdate?"":"d-hide"}" appid="${app.id}" title="Update App"><i class="icon icon-refresh"></i></button>
@@ -365,7 +365,7 @@ function getAppHTML(app, appInstalled, forInterface) {
     <button class="btn btn-link btn-action btn-lg ${appInstalled?"":"d-hide"}" appid="${app.id}" title="Remove App"><i class="icon icon-delete"></i></button>
     <button class="btn btn-link btn-action btn-lg ${app.custom?"":"d-hide"}" appid="${app.id}" title="Customise and Upload App"><i class="icon icon-menu"></i></button>`;
   if (forInterface=="myapps") html += `
-    <button class="btn btn-link btn-action btn-lg ${!app.custom?"":"d-hide"} btn-favourite" appid="${app.id}" title="Favorite"><i class="icon icon-favourite${favourite?" icon-favourite-active":""}"></i></button>
+    <button class="btn btn-link btn-action btn-lg btn-favourite" appid="${app.id}" title="Favorite"><i class="icon icon-favourite${favourite?" icon-favourite-active":""}"></i></button>
     <button class="btn btn-link btn-action btn-lg ${(appInstalled&&app.interface)?"":"d-hide"}" appid="${app.id}" title="Download data from app"><i class="icon icon-interface"></i></button>
     <button class="btn btn-link btn-action btn-lg ${version.canUpdate?'':'d-hide'}" appid="${app.id}" title="Update App"><i class="icon icon-refresh"></i></button>
     <button class="btn btn-link btn-action btn-lg" appid="${app.id}" title="Remove App"><i class="icon icon-delete"></i></button>`;
@@ -1058,7 +1058,8 @@ if (btn) btn.addEventListener("click",event=>{
 // Install all favourite apps in one go
 btn = document.getElementById("installfavourite");
 if (btn) btn.addEventListener("click",event=>{
-  installMultipleApps(SETTINGS.favourites, "favourite").catch(err=>{
+    const nonCustomFavourites = SETTINGS.favourites.filter(appId => appJSON.find(app => app.id === appId && !app.custom));
+    installMultipleApps(nonCustomFavourites, "favourite").catch(err=>{
     Progress.hide({sticky:true});
     showToast("App Install failed, "+err,"error");
   });


### PR DESCRIPTION
I was missing the possibility to mark some apps as favourites. Those apps were custom. The only possible reason I found why the functionality was hidden for them could be the install all favourites script. Therefore I exclude those apps from there.

Affected apps:
- Languages
- A Configurable Analog Clock
- Assisted GPS Update (AGPS)
- Beer Compass
- Contour Clock
- Custom Boot Code
- Custom QR Code
- Customised Welcome
- Espruino Control
- Font Clock
- Golf View
- Grocery
- HRM Accelerometer event recorder
- Hebrew Calendar
- Homework
- Image background clock
- OpenStreetMap
- POI Compass
- Route Viewer
- School Calendar
- Sliding Clock
- Solar Clock
- World Clock - 4 time zones
- Firmware Update

Before:
![image](https://user-images.githubusercontent.com/9334168/171947282-5a31bc49-f676-4f7c-a9cf-b1fa43103a0e.png)

After:
![image](https://user-images.githubusercontent.com/9334168/171947575-4eec8be4-684a-42f5-9206-2779c88e9fc4.png)
