### PR TITLE
Fix missing uploadOptions.apps

### DIFF
--- a/js/appinfo.js
+++ b/js/appinfo.js
@@ -318,6 +318,8 @@ var AppInfo = {
     uploadOptions = uploadOptions || {};
     if (uploadOptions.checkForClashes === undefined)
       uploadOptions.checkForClashes = true;
+    if (uploadOptions.apps === undefined)
+      uploadOptions.apps = appJSON;
 
     let promise = Promise.resolve();
     // Look up installed apps in our app JSON to get full info on them


### PR DESCRIPTION
Sometimes checkDependencies is called without oploadOptions, so apps is undefined.
e.g. https://github.com/espruino/EspruinoAppLoaderCore/blob/893c2dbbe5a93fbb80d035a695663b4f4cca8875/js/index.js#L979