### PR TITLE
Handle talking to Bangle in debug mode

### DIFF
--- a/js/comms.js
+++ b/js/comms.js
@@ -204,6 +204,7 @@ const Comms = {
         }
 
         if (result.startsWith("debug>")) {
+          console.log("<COMMS> watch was in debug mode, interrupting.", result);
           // we got a debug prompt - we interrupted the watch while JS was executing
           // so we're in debug mode, issue another ctrl-c to bump the watch out of it
           Puck.write("\x03", resolve);

--- a/js/comms.js
+++ b/js/comms.js
@@ -45,6 +45,9 @@ const Comms = {
       if (result=="" && (tries-- > 0)) {
         console.log(`<COMMS> reset: no response. waiting ${tries}...`);
         Puck.write("\x03",rstHandler);
+      } else if (result.endsWith("debug>")) {
+        console.log(`<COMMS> reset: watch in debug mode, interrupting...`);
+        Puck.write("\x03",rstHandler);
       } else {
         console.log(`<COMMS> reset: rebooted - sending commands to clear out any boot code`);
         // see https://github.com/espruino/BangleApps/issues/1759

--- a/js/comms.js
+++ b/js/comms.js
@@ -202,6 +202,17 @@ const Comms = {
           Progress.hide({sticky:true});
           return reject("");
         }
+
+        if (result.startsWith("debug>")) {
+          // we got a debug prompt - we interrupted the watch while JS was executing
+          // so we're in debug mode, issue another ctrl-c to bump the watch out of it
+          Puck.write("\x03", resolve);
+        } else {
+          resolve(result);
+        }
+      });
+    }).
+      then((result) => new Promise((resolve, reject) => {
         console.log("<COMMS> Ctrl-C gave",JSON.stringify(result));
         if (result.includes("ERROR") && !noReset) {
           console.log("<COMMS> Got error, resetting to be sure.");
@@ -252,8 +263,7 @@ const Comms = {
           console.log("<COMMS> getDeviceInfo", info);
           resolve(info);
         }, true /* callback on newline */);
-      });
-    });
+      }));
   },
   // Get an app's info file from Bangle.js
   getAppInfo : app => {

--- a/js/comms.js
+++ b/js/comms.js
@@ -218,7 +218,7 @@ const Comms = {
     }).
       then((result) => new Promise((resolve, reject) => {
         console.log("<COMMS> Ctrl-C gave",JSON.stringify(result));
-        if (result.includes("ERROR") && !noReset) {
+        if ((result.includes("ERROR") || results.endsWith("\r\ndebug>")) && !noReset) {
           console.log("<COMMS> Got error, resetting to be sure.");
           // If the ctrl-c gave an error, just reset totally and
           // try again (need to display 'BTN3' message)


### PR DESCRIPTION
When we interrupt, the watch may be executing code, in which case it'll move into debug mode. We now detect this and issue a second interrupt to move the watch out of debug mode, so we can continue to issue commands to it.

Closes espruino/BangleApps#1936