### PR TITLE
Trigger disconnect on connection failure, to revert UI state

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1084,6 +1084,7 @@ connectMyDeviceBtn.addEventListener("click", () => {
   } else {
     getInstalledApps(true).catch(err => {
       showToast("Device connection failed, "+err,"error");
+      Comms.disconnectDevice();
     });
   }
 });


### PR DESCRIPTION
Currently if I receive an error when connecting to a watch, the UI remains in a semi-connected state (e.g. the connect button continues to say "Disconnect", as-if connected). This clears any partial Puck connection and subsequently reverts the UI state to "disconnected"