### PR TITLE
Allow resetting the list of installed apps without complete init

### DIFF
--- a/lib/apploader.js
+++ b/lib/apploader.js
@@ -26,6 +26,11 @@ var apps = [];
 var device = { id : DEVICEID, appsInstalled : [] };
 var language; // Object of translations
 
+/* This resets the list of installed apps to an empty list.
+  It can be used in case the device behind the apploader has changed
+  after init (i.e. emulator factory reset) so the dependency
+  resolution does not skip no longer installed apps.
+*/
 exports.reset = function(){
   device.appsInstalled = [];
 }

--- a/lib/apploader.js
+++ b/lib/apploader.js
@@ -26,6 +26,10 @@ var apps = [];
 var device = { id : DEVICEID, appsInstalled : [] };
 var language; // Object of translations
 
+exports.reset = function(){
+  device.appsInstalled = [];
+}
+
 /* call with {
   DEVICEID:"BANGLEJS/BANGLEJS2"
   VERSION:"2v20"


### PR DESCRIPTION
Needed for https://github.com/espruino/BangleApps/pull/3399. There is probably a neater way to do this.
The reason for doing this is to allow correct install of dependencies after the emulator has been factory reset in preparation for the next test in `runapptests.js`.