### PR TITLE
Add missing locale conversions

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -73,6 +73,7 @@ let DEVICEINFO = [
 /* When a char is not in Espruino's iso8859-1 codepage, try and use
 these conversions */
 const CODEPAGE_CONVERSIONS = {
+  // letters
   "ą":"a",
   "ā":"a",
   "č":"c",
@@ -81,6 +82,7 @@ const CODEPAGE_CONVERSIONS = {
   "ę":"e",
   "ē":"e",
   "ģ":"g",
+  "ğ":"g",
   "ī":"i",
   "ķ":"k",
   "ļ":"l",
@@ -91,6 +93,7 @@ const CODEPAGE_CONVERSIONS = {
   "ř":"r",
   "ś":"s",
   "š":"s",
+  "ş":"s",
   "ū":"u",
   "ż":"z",
   "ź":"z",
@@ -102,7 +105,9 @@ const CODEPAGE_CONVERSIONS = {
   "Ě":"E",
   "Ę":"E",
   "Ē":"E",
+  "Ğ":"G",
   "Ģ":"G",
+  "ı":"i",
   "Ķ":"K",
   "Ļ":"L",
   "Ł":"L",
@@ -112,10 +117,15 @@ const CODEPAGE_CONVERSIONS = {
   "Ř":"R",
   "Ś":"S",
   "Š":"S",
+  "Ş":"S",
   "Ū":"U",
   "Ż":"Z",
   "Ź":"Z",
   "Ž":"Z",
+
+  // separators
+  " ":" ",
+  " ":" ",
 };
 
 /// Convert any character that cannot be displayed by Espruino's built in fonts


### PR DESCRIPTION
These characters were flagged by the script in https://github.com/espruino/BangleApps/pull/3268 - they are used in some of the locales but are not supported by Banglejs.

Some of them are only used in the CLDR data, but some of them are also used right now in real locales, so those locales are just broken. Even if we never merge the CLDR script, I don't see the harm in adding a few characters to this list.