### PR TITLE
Ensure device info is handled despite setTime() `await`s

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1012,6 +1012,8 @@ function getInstalledApps(refresh) {
         console.log("SETTINGS.settime=true and >2 seconds out - updating time");
         return Comms.setTime();
       }
+    })
+    .then(() => {
       // Show device info in more page:
       const deviceInfoElem = document.getElementById("more-deviceinfo");
       if (deviceInfoElem) {


### PR DESCRIPTION
This fixes a bug in #64 where, if the time was set, device info would be skipped:

https://github.com/espruino/EspruinoAppLoaderCore/blob/e496c04787e7e224bc1887f7f4785e523156fb2d/js/index.js#L1006-L1020

