### PR TITLE
Include app ID in toast messages, as well as app name

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -841,7 +841,7 @@ function uploadApp(app, options) {
         if (appJSON) {
           device.appsInstalled.push(appJSON);
         }
-        showToast(app.name + ' Uploaded!', 'success');
+        showToast(app.name +" ("+app.id+") "+ ' Uploaded!', 'success');
       }).catch(err => {
         showToast('Upload failed, ' + err, 'error');
       });
@@ -850,14 +850,14 @@ function uploadApp(app, options) {
 
 /** Prompt user and then remove app from the device */
 function removeApp(app) {
-  return showPrompt("Delete","Really remove '"+app.name+"'?")
+  return showPrompt("Delete", "Are you sure you want to delete "+app.name +" ("+app.id+")?")
     .then(() => startOperation({ name: "Remove App" }, () => getInstalledApps()
       .then(()=> Comms.removeApp(device.appsInstalled.find(a => a.id === app.id))) // a = from appid.info, app = from apps.json
       .then(()=>{
         device.appsInstalled = device.appsInstalled.filter(a=>a.id!=app.id);
-        showToast(app.name+" removed successfully","success");
+        showToast(app.name +" ("+app.id+")"+" removed successfully","success");
       }, err=>{
-        showToast(app.name+" removal failed, "+err,"error");
+        showToast("Removal of "+app.name +" ("+app.id+")"+" failed, "+err,"error");
       })));
 }
 
@@ -952,13 +952,13 @@ function updateApp(app, options) {
     remove.data = AppInfo.makeDataString(data)
     return Comms.removeApp(remove, {containsFileList:true, noReset:options.noReset, noFinish:options.noFinish});
   }).then(()=>{
-    showToast(`Updating ${app.name}...`);
+    showToast("Updating "+app.name +" ("+app.id+")...");
     device.appsInstalled = device.appsInstalled.filter(a=>a.id!=app.id);
     return checkDependencies(app,{checkForClashes:false});
   }).then(()=>Comms.uploadApp(app,{device:device,language:LANGUAGE,noReset:options.noReset, noFinish:options.noFinish})
   ).then((appJSON) => {
     if (appJSON) device.appsInstalled.push(appJSON);
-    showToast(app.name+" Updated!", "success");
+    showToast(app.name +" ("+app.id+")"+" Updated!", "success");
   }));
 }
 
@@ -1162,7 +1162,7 @@ function installMultipleApps(appIds, promptName) {
   }).then(()=> Comms.setTime()
   ).then(()=> Comms.showUploadFinished()
   ).then(()=>{
-    showToast("Apps successfully installed!","success");
+    showToast(appCount+" apps successfully installed!","success");
     return getInstalledApps(true);
   });
 }

--- a/js/index.js
+++ b/js/index.js
@@ -841,30 +841,38 @@ function uploadApp(app, options) {
         if (appJSON) {
           device.appsInstalled.push(appJSON);
         }
-        showToast(app.name +" ("+app.id+") "+ ' Uploaded!', 'success');
+        showToast(formatAppName(app)+ ' Uploaded!', 'success');
       }).catch(err => {
-        showToast("Upload of" +app.name +" ("+app.id+") "+" failed",  + err, 'error');
+        showToast("Upload of" +formatAppName(app)+" failed",  + err, 'error');
       });
   }));
 }
-
+/** Format app name into a string like App Name (AppID)*/
+function formatAppName(app){
+  //check if id is the same as the name, in which case we can just return the name...
+  if(app.name.trim().toLowerCase()===app.id.trim().toLowerCase()){
+    return app.name;
+  }else{
+    return formatAppName(app);
+  }
+}
 /** Prompt user and then remove app from the device */
 function removeApp(app) {
-  return showPrompt("Delete", "Are you sure you want to delete "+app.name +" ("+app.id+")?")
+  return showPrompt("Delete", "Are you sure you want to delete "+formatAppName(app)+"?")
     .then(() => startOperation({ name: "Remove App" }, () => getInstalledApps()
       .then(()=> Comms.removeApp(device.appsInstalled.find(a => a.id === app.id))) // a = from appid.info, app = from apps.json
       .then(()=>{
         device.appsInstalled = device.appsInstalled.filter(a=>a.id!=app.id);
-        showToast(app.name +" ("+app.id+")"+" removed successfully","success");
+        showToast(formatAppName(app)+" removed successfully","success");
       }, err=>{
-        showToast("Removal of "+app.name +" ("+app.id+")"+" failed, "+err,"error");
+        showToast("Removal of "+formatAppName(app)+" failed, "+err,"error");
       })));
 }
 
 /** Show window for a new app and finally upload it */
 function customApp(app) {
   return handleCustomApp(app).then(() => {
-    showToast(app.name+" Uploaded!", "success");
+    showToast(formatAppName()+" Uploaded!", "success");
     refreshMyApps();
     refreshLibrary();
   }).catch(err => {
@@ -952,13 +960,13 @@ function updateApp(app, options) {
     remove.data = AppInfo.makeDataString(data)
     return Comms.removeApp(remove, {containsFileList:true, noReset:options.noReset, noFinish:options.noFinish});
   }).then(()=>{
-    showToast("Updating "+app.name +" ("+app.id+")...");
+    showToast("Updating "+formatAppName(app)+"...");
     device.appsInstalled = device.appsInstalled.filter(a=>a.id!=app.id);
     return checkDependencies(app,{checkForClashes:false});
   }).then(()=>Comms.uploadApp(app,{device:device,language:LANGUAGE,noReset:options.noReset, noFinish:options.noFinish})
   ).then((appJSON) => {
     if (appJSON) device.appsInstalled.push(appJSON);
-    showToast(app.name +" ("+app.id+")"+" Updated!", "success");
+    showToast(formatAppName(app)+" Updated!", "success");
   }));
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -843,7 +843,7 @@ function uploadApp(app, options) {
         }
         showToast(app.name +" ("+app.id+") "+ ' Uploaded!', 'success');
       }).catch(err => {
-        showToast('Upload failed, ' + err, 'error');
+        showToast("Upload of" +app.name +" ("+app.id+") "+" failed",  + err, 'error');
       });
   }));
 }


### PR DESCRIPTION
There is some confusion when updating/adding/removing apps, as sometimes the app ID can be something wildly different than the name. eg: (`gallifr` --> `Time Traveller's Clock`).
I thought it would be good if you can see both the App name that you are familiar with, and the id that appears in storage...

Toasts now will show something like:

**Time Traveller's Clock (gallifr) uploaded**


I also consolidated that into a reusable function that returns the string above, but if the app id and the name are the same,   eg: (BackLite, backlite), just return the name.