### PR TITLE
Fix reference to undefined device object in appinfo

### DIFF
--- a/js/appinfo.js
+++ b/js/appinfo.js
@@ -261,7 +261,7 @@ let AppInfo = {
         return AppInfo.createAppJSON(app, fileContents);
       }).then(fileContents => {
         // check for the need to add compatibility fixes, and add those if needed
-        if (device.id=="BANGLEJS3" && app.supports && app.supports.includes("BANGLEJS3_COMPAT")) {
+        if (options.device.id=="BANGLEJS3" && app.supports && app.supports.includes("BANGLEJS3_COMPAT")) {
           let entrypoint = fileContents.find(f=>f.name==app.id+".app.js");
           if (entrypoint) entrypoint.content = "Bangle.setLCDMode('176x176');\n" + entrypoint.content;
         }


### PR DESCRIPTION
This currently causes the CI app tests for the BangleApps repo to essentially just always return fine since no tests are actually run. During test runs this errors out and does not print an error because there is no catch on the apploader.getAppFilesString(app) promise.

There currently seems to be something wrong with the test reset since running single tests (not all tests for a single app) works while running more than one fails with `Uncaught SyntaxError: Got [ERASED] expected EOF`. I'm pretty sure that is a different issue and only hidden by this one.